### PR TITLE
Add support for loading private key by URI

### DIFF
--- a/key.go
+++ b/key.go
@@ -371,7 +371,7 @@ func LoadPrivateKeyByUri(uri string) (PrivateKey, error) {
 		return nil, ErrLoadingKey
 	}
 
-	key := C.OSSL_STORE_INFO_get1PKEY(info)
+	key := C.OSSL_STORE_INFO_get1_PKEY(info)
 	if key == nil {
 		return nil, ErrLoadingKey
 	}

--- a/key.go
+++ b/key.go
@@ -18,6 +18,7 @@ package openssl
 // #include <openssl/rsa.h>
 // #include <openssl/pem.h>
 // #include <openssl/x509v3.h>
+// #include <openssl/store.h>
 import "C"
 
 import (
@@ -343,6 +344,34 @@ func LoadPrivateKeyFromDER(derBlock []byte) (PrivateKey, error) {
 
 	key := C.d2i_PrivateKey_bio(bio.ptr, nil)
 	runtime.KeepAlive(bio)
+	if key == nil {
+		return nil, ErrLoadingKey
+	}
+
+	return pKeyFromKey(key), nil
+}
+
+// LoadPrivateKeyByUri loads a private key similar to the openssl command.
+// For example, you can pass in "handle:0x81000000"
+//
+// This function is a more simple implementation in load_key_certs_crls that the
+// openssl command line utility uses, so most things that you can pass into the
+// command line utility should work here.
+func LoadPrivateKeyByUri(uri string) (PrivateKey, error) {
+	cstrUri := C.CString(uri)
+	defer C.free(unsafe.Pointer(cstrUri))
+
+	ctx := C.OSSL_STORE_open_ex(C.CString(uri), nil, nil, nil, nil, nil, nil, nil)
+	if ctx == nil {
+		return nil, ErrLoadingKey
+	}
+
+	info := C.OSSL_STORE_load(ctx)
+	if info == nil {
+		return nil, ErrLoadingKey
+	}
+
+	key := C.OSSL_STORE_INFO_get1PKEY(info)
 	if key == nil {
 		return nil, ErrLoadingKey
 	}


### PR DESCRIPTION
I needed to load a private key that is stored in a TPM. The current APIs are assuming that the private key is a file is on disk. I could make openssl work with the TPM via the command line tool, so I looked through the code and put the essential C code that I could find into a new way to load keys.

Tested on my system and was able to use the TPM based private key.